### PR TITLE
Added a route for athlete score history

### DIFF
--- a/models/athleteScoreHistory.go
+++ b/models/athleteScoreHistory.go
@@ -1,0 +1,16 @@
+package models
+
+import "time"
+
+// AthleteScoreHistory represents individual score history entries
+type ScoreHistoryEntry struct {
+	Date  time.Time `json:"date" db:"created_dt"`
+	Score int       `json:"score" db:"new_score"`
+}
+
+// AthleteScoreHistory represents the response format for the history endpoint
+type AthleteScoreHistory struct {
+	StyleId   int                 `json:"styleId" db:"style_id"`
+	StyleName string              `json:"styleName" db:"style_name"`
+	History   []ScoreHistoryEntry `json:"history"`
+}

--- a/router/router.go
+++ b/router/router.go
@@ -132,6 +132,7 @@ func CreateRouter() *mux.Router {
 	router.HandleFunc(base_url+"/score/{athlete_id}", athleteScoreHandler.GetAthleteScore).Methods("GET")
 	router.HandleFunc(base_url+"/score/{athlete_id}/all", athleteScoreHandler.GetAthleteScore).Methods("GET")
 	router.HandleFunc(base_url+"/score/{athlete_id}/style/{style_id}", athleteScoreHandler.GetAthleteScoreByStyle).Methods("GET")
+	router.HandleFunc(base_url+"/score/{athlete_id}/style/{style_id}/history", athleteScoreHandler.GetAthleteScoreHistoryByStyle).Methods("GET")
 
 	// Feed routes
 	router.HandleFunc(base_url+"/feed/{athlete_id}", feedHandler.GetFeedByAthleteID).Methods("GET")

--- a/services/athleteScoreHandler.go
+++ b/services/athleteScoreHandler.go
@@ -76,3 +76,36 @@ func (h *AthleteScoreHandler) GetAthleteScoreByStyle(w http.ResponseWriter, r *h
 		http.Error(w, "Error encoding response", http.StatusInternalServerError)
 	}
 }
+
+func (h *AthleteScoreHandler) GetAthleteScoreHistoryByStyle(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	vars := mux.Vars(r)
+	athleteIdStr := vars["athlete_id"]
+	styleIdStr := vars["style_id"]
+
+	athleteId, err := strconv.Atoi(athleteIdStr)
+	if err != nil {
+		log.Printf("Invalid athlete_id: %v\n", err)
+		http.Error(w, "Invalid athlete_id", http.StatusBadRequest)
+		return
+	}
+
+	styleId, err := strconv.Atoi(styleIdStr)
+	if err != nil {
+		log.Printf("Invalid style_id: %v\n", err)
+		http.Error(w, "Invalid style_id", http.StatusBadRequest)
+		return
+	}
+
+	history, err := h.service.GetAthleteScoreHistoryByStyle(athleteId, styleId)
+	if err != nil {
+		log.Printf("Error getting athlete score history: %v\n", err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	if err := json.NewEncoder(w).Encode(history); err != nil {
+		log.Printf("Error encoding response: %v\n", err)
+		http.Error(w, "Error encoding response", http.StatusInternalServerError)
+	}
+}

--- a/services/athleteScoreService.go
+++ b/services/athleteScoreService.go
@@ -36,6 +36,14 @@ func (s *AthleteScoreService) GetAthleteScoreByStyle(athleteId, styleId int) (mo
 	return score, nil
 }
 
+func (s *AthleteScoreService) GetAthleteScoreHistoryByStyle(athleteId, styleId int) (models.AthleteScoreHistory, error) {
+	history, err := s.repo.GetAthleteScoreHistoryByStyle(athleteId, styleId)
+	if err != nil {
+		return models.AthleteScoreHistory{}, err
+	}
+	return history, nil
+}
+
 func (s *AthleteScoreService) CreateAthleteScoreUponRegistration(athleteId, styleId int) error {
 	return s.repo.CreateAthleteScoreUponRegistration(athleteId, styleId)
 }


### PR DESCRIPTION
This pull request introduces a new feature to retrieve the score history of an athlete for a specific style. It includes changes across multiple layers of the application, from the database model to the API endpoint, ensuring a comprehensive implementation of this functionality.
### Models
* Added a new `AthleteScoreHistory` model and its associated `ScoreHistoryEntry` to represent the structure of the score history response. (`models/athleteScoreHistory.go`, [models/athleteScoreHistory.goR1-R16](diffhunk://#diff-6ccaa7b88f337133c7d99d160024abb3073fabb289b5c96311d55bc434701007R1-R16))

### Repositories
* Implemented the `GetAthleteScoreHistoryByStyle` method in `AthleteScoreRepository` to query the database for an athlete's score history by style, including style metadata and historical scores. (`repositories/athleteScoreRepository.go`, [repositories/athleteScoreRepository.goR172-R199](diffhunk://#diff-147908e091be89689cfc7b0b20b320480db57a02378b3e727976e3a78d7b1dafR172-R199))

### Services
* Added a `GetAthleteScoreHistoryByStyle` method in `AthleteScoreService` to act as a service layer abstraction for retrieving score history. (`services/athleteScoreService.go`, [services/athleteScoreService.goR39-R46](diffhunk://#diff-c3a49ab00cf6b84357c94985aacda7fe97065cdeddded6ff74539d3a5a549cc9R39-R46))

### Handlers
* Created a new HTTP handler `GetAthleteScoreHistoryByStyle` in `AthleteScoreHandler` to handle requests for athlete score history by style, including input validation and JSON response encoding. (`services/athleteScoreHandler.go`, [services/athleteScoreHandler.goR79-R111](diffhunk://#diff-d49ddb358cdc48175e6871c443b1eade6a96cc5bb12e032bb4b261ead346e631R79-R111))

### Routing
* Added a new route `/score/{athlete_id}/style/{style_id}/history` to the router to expose the new endpoint for fetching score history. (`router/router.go`, [router/router.goR135](diffhunk://#diff-c399d26e7f23b713ce01946ac9e0e6f1fc94d692e8a086180191901da91b6964R135))